### PR TITLE
Add url to repo in metainfo

### DIFF
--- a/data/com.github.sdv43.whaler.appdata.xml.in
+++ b/data/com.github.sdv43.whaler.appdata.xml.in
@@ -28,6 +28,8 @@
       <image>https://raw.githubusercontent.com/sdv43/whaler/master/data/images/screenshots/screenshot-2.png</image>
     </screenshot>
   </screenshots>
+  <url type="homepage">https://github.com/sdv43/whaler</url>
+  <url type="bugtracker">https://github.com/sdv43/whaler/issues</url>
   <content_rating type="oars-1.1" />
   <provides>
     <binary>com.github.sdv43.whaler</binary>


### PR DESCRIPTION
Add the url to the github repo in the metainfo so that users can easily access the repo directly from the appcenter